### PR TITLE
fix(package): update gatsby-remark-images to version 1.5.43

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-sharp": "1.6.27",
     "gatsby-plugin-styled-components": "2.0.5",
     "gatsby-remark-copy-linked-files": "1.5.26",
-    "gatsby-remark-images": "1.5.41",
+    "gatsby-remark-images": "1.5.43",
     "gatsby-remark-prismjs": "1.2.12",
     "gatsby-source-filesystem": "1.5.18",
     "gatsby-transformer-remark": "1.7.30",


### PR DESCRIPTION
Closes #204