### PR TITLE
fix(package): update gatsby-remark-images to version 1.5.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gatsby-plugin-sharp": "1.6.28",
     "gatsby-plugin-styled-components": "2.0.6",
     "gatsby-remark-copy-linked-files": "1.5.27",
-    "gatsby-remark-images": "1.5.44",
+    "gatsby-remark-images": "1.5.46",
     "gatsby-remark-prismjs": "1.2.15",
     "gatsby-source-filesystem": "1.5.19",
     "gatsby-transformer-remark": "1.7.32",


### PR DESCRIPTION
Closes #247