### PR TITLE
fix(package): update gatsby-remark-prismjs to version 1.2.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gatsby-plugin-styled-components": "2.0.9",
     "gatsby-remark-copy-linked-files": "1.5.30",
     "gatsby-remark-images": "1.5.56",
-    "gatsby-remark-prismjs": "1.2.17",
+    "gatsby-remark-prismjs": "1.2.20",
     "gatsby-source-filesystem": "1.5.27",
     "gatsby-transformer-remark": "1.7.37",
     "react-helmet": "5.2.0",


### PR DESCRIPTION
Closes #339

