### PR TITLE
fix(package): update gatsby-remark-copy-linked-files to version 1.5.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "gatsby-plugin-react-next": "1.0.11",
     "gatsby-plugin-sharp": "1.6.47",
     "gatsby-plugin-styled-components": "2.0.11",
-    "gatsby-remark-copy-linked-files": "1.5.35",
+    "gatsby-remark-copy-linked-files": "1.5.37",
     "gatsby-remark-images": "1.5.66",
     "gatsby-remark-prismjs": "2.0.3",
     "gatsby-source-filesystem": "1.5.38",


### PR DESCRIPTION
Closes #521

